### PR TITLE
Fixing main toolbar title.

### DIFF
--- a/app/src/qt/main_toolbar_view.cpp
+++ b/app/src/qt/main_toolbar_view.cpp
@@ -21,7 +21,7 @@
 namespace m8r {
 
 MainToolbarView::MainToolbarView(MainWindowView* mainWindowView)
-    : QToolBar{mainWindowView}, mainWindow{mainWindowView}
+    : QToolBar{tr("Main Toolbar"), mainWindowView}, mainWindow{mainWindowView}
 {
 
     actionNewOutlineOrNote = addAction(QIcon(":/icons/new.svg"), tr("New Notebook"));


### PR DESCRIPTION
There is no toolbar name in the context menu when right-clicking on menu bar or an empty space in toolbar:

![screenshot_20181114_234418](https://user-images.githubusercontent.com/232116/48498629-3a2c6c00-e869-11e8-9d27-9f2e413ebb34.png)

A minor fix for the UX/UI:

![screenshot_20181114_234531](https://user-images.githubusercontent.com/232116/48498631-3ac50280-e869-11e8-93da-5e6062147f09.png)