### PR TITLE
fix compilation with QtWebEngine

### DIFF
--- a/app/src/qt/note_view_presenter.cpp
+++ b/app/src/qt/note_view_presenter.cpp
@@ -110,7 +110,7 @@ void NoteViewPresenter::refreshLivePreview()
     view->setHtml(QString::fromStdString(html));
 
     // IMPROVE share code between O header and N
-#if not defined(_WIN32) && not defined(__APPLE__)
+#if not defined(_WIN32) && not defined(__APPLE__) && not defined(MF_QT_WEB_ENGINE)
     // WebView: scroll to same pct view
     if(scrollbar) {
         if(scrollbar->maximum()) {

--- a/app/src/qt/note_view_presenter.h
+++ b/app/src/qt/note_view_presenter.h
@@ -27,7 +27,7 @@
 #include "note_view.h"
 #include "note_view_model.h"
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if not defined(__APPLE__) && not defined(_WIN32) && not defined(MF_QT_WEB_ENGINE)
 #include <QWebFrame>
 #endif
 

--- a/app/src/qt/outline_header_view_presenter.cpp
+++ b/app/src/qt/outline_header_view_presenter.cpp
@@ -101,7 +101,7 @@ void OutlineHeaderViewPresenter::refreshLivePreview()
     view->setHtml(QString::fromStdString(html));
 
     // IMPROVE share code between O header and N
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if not defined(__APPLE__) && not defined(_WIN32) && not defined(MF_QT_WEB_ENGINE)
     // WebView: scroll to same pct view
     if(scrollbar) {
         if(scrollbar->maximum()) {


### PR DESCRIPTION
Hi ! 
I find `mindforger` very useful and I help packaging it for  [NixOS](https://nixos.org/). 
We're trying to [deprecate](https://github.com/NixOS/nixpkgs/issues/53079) `QtWebKit` across all NixOS packages.
As part of that work I found that `mindforger` accepts `"CONFIG+=mfwebengine"` and then tries to compile with QtWebEngine.
When I ran the build I found that the project does not fully successfully compile with that option though.
This PR is an attempt to fix that - the resulting binary works very well on NixOS, I however haven't tested it on Windows nor MacOS.
I think I shouldn't have broken these targets, just by reading the the code, but would probably be best to test on those ?

For reference - [here's](https://github.com/NixOS/nixpkgs/pull/122476) the PR I'm trying to land to change the NixOS package definition - it includes these changes as a patch for now, but the reviewers suggested upstreaming first, hence my PR here :)

Hope this helps, please let me know what you think :)

If this makes sense, I would like to open another PR for the second patch that makes the output directories relocatable, but didn't want to spam with PRs without opening up a conversation.