### PR TITLE
Added modal parent to Save/Discard prompts

### DIFF
--- a/app/src/qt/note_editor_view.cpp
+++ b/app/src/qt/note_editor_view.cpp
@@ -411,7 +411,9 @@ void NoteEditorView::keyPressEvent(QKeyEvent* event)
                 QMessageBox msgBox{
                     QMessageBox::Question,
                     tr("Exit Editor"),
-                    tr("Do you really want to exit editor without saving?")
+                    tr("Do you really want to exit editor without saving?"),
+                    {},
+                    parent
                 };
                 QPushButton* yes = msgBox.addButton("&Yes", QMessageBox::YesRole);
 #ifdef __APPLE__

--- a/app/src/qt/orloj_presenter.cpp
+++ b/app/src/qt/orloj_presenter.cpp
@@ -154,13 +154,15 @@ OrlojPresenter::OrlojPresenter(MainWindowPresenter* mainPresenter,
         this, SLOT(slotShowOutlineHeader()));
 }
 
-int dialogSaveOrCancel()
+int dialogSaveOrCancel(QWidget* view)
 {
     // l10n by moving this dialog either to Qt class OR view class
     QMessageBox msgBox{
         QMessageBox::Question,
         QObject::tr("Save Note"),
-        QObject::tr("Do you want to save changes?")
+        QObject::tr("Do you want to save changes?"),
+        {},
+        view
     };
 
     QPushButton* discard = msgBox.addButton(
@@ -750,7 +752,7 @@ bool OrlojPresenter::avoidDataLossOnNoteEdit()
             if(Configuration::getInstance().isUiEditorAutosave()) {
                 decision = OrlojButtonRoles::SAVE_ROLE;
             } else {
-                decision = dialogSaveOrCancel();
+                decision = dialogSaveOrCancel(view);
             }
 
             switch(decision) {
@@ -774,7 +776,7 @@ bool OrlojPresenter::avoidDataLossOnNoteEdit()
                 return true;
             }
         } else if(activeFacet == OrlojPresenterFacets::FACET_EDIT_OUTLINE_HEADER) {
-            int decision = dialogSaveOrCancel();
+            int decision = dialogSaveOrCancel(view);
             switch(decision) {
             case OrlojButtonRoles::DISCARD_ROLE:
                 // do nothing


### PR DESCRIPTION
This fixes the following problem:

When user switches to another note, or presses [Esc] key, a Save/Discard/Cancel dialog appears.
If the user at this time switches to another application, then it would not be possible to switch back to mindforger main window by alt-tab or clicking on it. It is possible only by switching exactly to the *the prompt*.

This fixes it by providing a proper *modal parent* to these two dialogs, as most other prompts already have.